### PR TITLE
Fix crashes, zoom highlight, countdown & more

### DIFF
--- a/AllHandsOnDeck/Resources/de.lproj/Localizable.strings
+++ b/AllHandsOnDeck/Resources/de.lproj/Localizable.strings
@@ -12,6 +12,8 @@
 /* ── HostSessionView ── */
 "OK" = "OK";
 "Schließen" = "Schließen";
+"Hohe Auflösung (48 MP)" = "Hohe Auflösung (48 MP)";
+"Maximale Auflösung — langsamere Verarbeitung." = "Maximale Auflösung — langsamere Verarbeitung.";
 "Sessions enden automatisch nach Ablauf der TTL — kein Speichern, keine Accounts, keine Spuren." = "Sessions enden automatisch nach Ablauf der TTL — kein Speichern, keine Accounts, keine Spuren.";
 "Anfrage von der Crew — bestätige in den Einstellungen." = "Anfrage von der Crew — bestätige in den Einstellungen.";
 "Abbrechen" = "Abbrechen";
@@ -69,6 +71,7 @@
 "nearby.hostStartingSession" = "%@ startet ein Gruppenfoto";
 "burst.shotNumber" = "Aufnahme %d";
 "host.startTimer" = "Start %ds";
+"result.closingIn" = "Schließt in %d…";
 
 /* ── Alert titles ── */
 "Hinweis" = "Hinweis";

--- a/AllHandsOnDeck/Resources/en.lproj/Localizable.strings
+++ b/AllHandsOnDeck/Resources/en.lproj/Localizable.strings
@@ -12,6 +12,8 @@
 /* ── HostSessionView ── */
 "OK" = "OK";
 "Schließen" = "Close";
+"Hohe Auflösung (48 MP)" = "High Resolution (48 MP)";
+"Maximale Auflösung — langsamere Verarbeitung." = "Maximum resolution — slower processing.";
 "Sessions enden automatisch nach Ablauf der TTL — kein Speichern, keine Accounts, keine Spuren." = "Sessions end automatically after TTL — no saving, no accounts, no traces.";
 "Anfrage von der Crew — bestätige in den Einstellungen." = "Request from crew — confirm in settings.";
 "Abbrechen" = "Cancel";
@@ -69,6 +71,7 @@
 "nearby.hostStartingSession" = "%@ is starting a group photo";
 "burst.shotNumber" = "Shot %d";
 "host.startTimer" = "Start %ds";
+"result.closingIn" = "Closing in %d…";
 
 /* ── Alert titles ── */
 "Hinweis" = "Note";

--- a/AllHandsOnDeck/Services/Camera/CameraService.swift
+++ b/AllHandsOnDeck/Services/Camera/CameraService.swift
@@ -179,6 +179,7 @@ final class CameraService: NSObject, ObservableObject {
             Task { @MainActor in
                 self.isFrontCamera = front
                 self.zoomFactor = 1.0
+                self.isHighResEnabled = false
                 if front { self.isTorchOn = false }
             }
         }
@@ -193,7 +194,10 @@ final class CameraService: NSObject, ObservableObject {
             if let device = self.currentInput?.device, !device.hasTorch {
                 Task { @MainActor in self.isTorchOn = false }
             }
-            Task { @MainActor in self.zoomFactor = 1.0 }
+            Task { @MainActor in
+                self.zoomFactor = 1.0
+                self.isHighResEnabled = false
+            }
         }
     }
 
@@ -201,17 +205,14 @@ final class CameraService: NSObject, ObservableObject {
         let enable = !isHighResEnabled
         sessionQueue.async { [weak self] in
             guard let self, let device = self.currentInput?.device else { return }
+            let dims = device.activeFormat.supportedMaxPhotoDimensions
+            guard !dims.isEmpty else { return }
+            let target = enable
+                ? dims.max(by: { Int($0.width) * Int($0.height) < Int($1.width) * Int($1.height) })
+                : dims.min(by: { Int($0.width) * Int($0.height) < Int($1.width) * Int($1.height) })
+            guard let target else { return }
             self.session.beginConfiguration()
-            if enable {
-                let maxDims = device.activeFormat.supportedMaxPhotoDimensions
-                    .max(by: { Int($0.width) * Int($0.height) < Int($1.width) * Int($1.height) })
-                if let dims = maxDims {
-                    self.photoOutput.maxPhotoDimensions = dims
-                }
-            } else {
-                // Reset to default (0,0 lets AVFoundation choose)
-                self.photoOutput.maxPhotoDimensions = CMVideoDimensions(width: 0, height: 0)
-            }
+            self.photoOutput.maxPhotoDimensions = target
             self.session.commitConfiguration()
             Task { @MainActor in self.isHighResEnabled = enable }
         }

--- a/AllHandsOnDeck/ViewModels/HostSessionViewModel.swift
+++ b/AllHandsOnDeck/ViewModels/HostSessionViewModel.swift
@@ -113,8 +113,12 @@ final class HostSessionViewModel: ObservableObject {
         $participants.sink { [weak self] _ in self?.pushWatchSnapshot() }.store(in: &subs)
         countdown.$state.sink { [weak self] _ in self?.pushWatchSnapshot() }.store(in: &subs)
 
-        // Forward countdown changes so SwiftUI re-renders host view.
+        // Forward countdown and camera changes so SwiftUI re-renders host view.
         countdown.objectWillChange
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.objectWillChange.send() }
+            .store(in: &subs)
+        camera.objectWillChange
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in self?.objectWillChange.send() }
             .store(in: &subs)

--- a/AllHandsOnDeck/Views/Host/HostSessionView.swift
+++ b/AllHandsOnDeck/Views/Host/HostSessionView.swift
@@ -7,6 +7,8 @@ struct HostSessionView: View {
     @State private var baseZoom: CGFloat = 1.0
     @State private var showZoomLabel: Bool = false
     @State private var zoomHideTask: Task<Void, Never>? = nil
+    @State private var postCaptureSecsLeft: Int? = nil
+    @State private var postCaptureTask: Task<Void, Never>? = nil
     let onSessionCreated: (String) -> Void
 
     init(hostName: String, allowWebJoin: Bool = false, onSessionCreated: @escaping (String) -> Void) {
@@ -323,7 +325,7 @@ struct HostSessionView: View {
                         get: { vm.session.timerDuration },
                         set: { vm.setTimerDuration($0) }
                     ),
-                    options: [10, 20, 30]
+                    options: [5, 10, 20, 30]
                 )
             }
 
@@ -368,7 +370,7 @@ struct HostSessionView: View {
                 Image(systemName: "camera.aperture")
                     .foregroundStyle(vm.camera.isHighResEnabled ? Theme.gold : Theme.mist)
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("High Resolution (48 MP)")
+                    Text("Hohe Auflösung (48 MP)")
                         .font(.system(size: 14, weight: .heavy, design: .rounded))
                         .foregroundStyle(Theme.bone)
                     Text("Maximale Auflösung — langsamere Verarbeitung.")
@@ -435,16 +437,31 @@ struct HostSessionView: View {
                         .clipShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
                         .padding(.horizontal, 16)
                 }
-                HStack(spacing: 10) {
-                    PrimaryButton(title: "Noch einmal", systemImage: "arrow.counterclockwise", style: .secondary) {
-                        vm.discardCapture()
+                if let secs = postCaptureSecsLeft {
+                    HStack {
+                        Text(String(format: String(localized: "result.closingIn"), secs))
+                            .font(.system(size: 13, weight: .heavy, design: .rounded))
+                            .foregroundStyle(Theme.mist)
+                        Spacer()
+                        PrimaryButton(title: "Schließen", style: .ghost) {
+                            cancelPostCapture()
+                            vm.discardCapture()
+                        }
                     }
-                    PrimaryButton(title: "Speichern", systemImage: "square.and.arrow.down", style: .primary) {
-                        savePhoto(photo)
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 24)
+                } else {
+                    HStack(spacing: 10) {
+                        PrimaryButton(title: "Noch einmal", systemImage: "arrow.counterclockwise", style: .secondary) {
+                            vm.discardCapture()
+                        }
+                        PrimaryButton(title: "Speichern", systemImage: "square.and.arrow.down", style: .primary) {
+                            savePhoto(photo)
+                        }
                     }
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 24)
                 }
-                .padding(.horizontal, 16)
-                .padding(.bottom, 24)
             }
         }
     }
@@ -453,6 +470,28 @@ struct HostSessionView: View {
         guard let img = photo.uiImage else { return }
         UIImageWriteToSavedPhotosAlbum(img, nil, nil, nil)
         Haptics.success()
-        vm.discardCapture()
+        startPostCaptureCountdown()
+    }
+
+    private func startPostCaptureCountdown() {
+        postCaptureTask?.cancel()
+        postCaptureSecsLeft = 10
+        postCaptureTask = Task { @MainActor in
+            for i in stride(from: 10, through: 0, by: -1) {
+                guard !Task.isCancelled else { return }
+                postCaptureSecsLeft = i
+                if i == 0 { break }
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+            }
+            guard !Task.isCancelled else { return }
+            postCaptureSecsLeft = nil
+            vm.discardCapture()
+        }
+    }
+
+    private func cancelPostCapture() {
+        postCaptureTask?.cancel()
+        postCaptureTask = nil
+        postCaptureSecsLeft = nil
     }
 }

--- a/AllHandsOnDeckTests/PhotoSessionTests.swift
+++ b/AllHandsOnDeckTests/PhotoSessionTests.swift
@@ -53,7 +53,7 @@ final class PhotoSessionTests: XCTestCase {
         let s = PhotoSession(id: "ABCDEF1234", hostName: "Captain")
         XCTAssertEqual(
             s.joinURL.absoluteString,
-            "https://allhands.captainleopard.app/join/ABCDEF1234"
+            "https://all-hands-on-deck-ae29e.web.app/join/ABCDEF1234"
         )
     }
 }

--- a/project.yml
+++ b/project.yml
@@ -10,6 +10,7 @@ options:
   xcodeVersion: "16.0"
   groupSortPosition: top
   developmentLanguage: de
+  organizationName: "Alexander Brunker"
 
 # ─── Shared build settings ───────────────────────────────────────────────────
 settings:


### PR DESCRIPTION
## Changes
- **Zoom lens buttons**: Forward `camera.objectWillChange` → lens/torch buttons now highlight active state
- **High-res crash**: `toggleHighRes` was passing invalid `CMVideoDimensions(0,0)` — now uses min dimension from `supportedMaxPhotoDimensions`; HD state resets on lens switch/flip
- **Countdown on host**: Forward `countdown.objectWillChange` in both ViewModels so SwiftUI re-renders
- **Pinch zoom**: Fix `baseZoom` race in `.onEnded`; reset on flip/lens switch
- **Performance**: `isWritingFrame` guard prevents Firebase PUT pile-up
- **Orientation**: `capturePhoto` reads `UIDevice.current.orientation` before dispatching
- **5s timer option**: `[5, 10, 20, 30]`
- **Post-capture hold**: 10s countdown after saving photo before dismissing result overlay
- **Webapp**: "Fertig" button dismisses final photo overlay
- **Localization**: High-res label + `result.closingIn` in de/en; all existing strings already covered
- **Org name**: `Alexander Brunker` in `project.yml`
- **Tests**: All 36 pass; fixed `PhotoSessionTests` URL assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)