### PR TITLE
[APP-86] Fix web viewer beta QR join and host photo review UI

### DIFF
--- a/AllHandsOnDeck/Core/Models/PhotoSession.swift
+++ b/AllHandsOnDeck/Core/Models/PhotoSession.swift
@@ -53,10 +53,16 @@ struct PhotoSession: Identifiable, Hashable, Codable, Sendable {
             ?? Bundle.main.object(forInfoDictionaryKey: "WEB_JOIN_BASE_URL") as? String
             ?? ""
         let pathURL: URL
-        if !base.isEmpty {
-            pathURL = URL(string: "\(base)/join/\(id)")!
+        let normalizedBase = base
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: #"/+$"#, with: "", options: .regularExpression)
+        if !normalizedBase.isEmpty,
+           let webURL = URL(string: "\(normalizedBase)/join/\(id)") {
+            pathURL = webURL
+        } else if let appURL = URL(string: "allhands://join/\(id)") {
+            pathURL = appURL
         } else {
-            pathURL = URL(string: "allhands://join/\(id)")!
+            preconditionFailure("Invalid join URL")
         }
         guard let joinToken else { return pathURL }
 

--- a/AllHandsOnDeck/Core/Services/Camera/CameraService.swift
+++ b/AllHandsOnDeck/Core/Services/Camera/CameraService.swift
@@ -398,6 +398,9 @@ final class CameraService: NSObject, ObservableObject {
     // MARK: - Capture
 
     func capturePhoto() async throws -> Data {
+        if bypassCameraForUITests {
+            return Self.makeUITestPhotoData()
+        }
         if photoContinuation != nil {
             throw NSError(domain: "Camera", code: -2,
                           userInfo: [NSLocalizedDescriptionKey: "Capture already in progress."])
@@ -416,6 +419,22 @@ final class CameraService: NSObject, ObservableObject {
                 self.photoOutput.capturePhoto(with: settings, delegate: self)
             }
         }
+    }
+
+    private static func makeUITestPhotoData() -> Data {
+        let size = CGSize(width: 960, height: 1280)
+        let renderer = UIGraphicsImageRenderer(size: size)
+        let image = renderer.image { context in
+            UIColor(red: 0.08, green: 0.09, blue: 0.11, alpha: 1).setFill()
+            context.fill(CGRect(origin: .zero, size: size))
+
+            UIColor(red: 0.96, green: 0.72, blue: 0.18, alpha: 1).setFill()
+            context.cgContext.fillEllipse(in: CGRect(x: 120, y: 140, width: 220, height: 220))
+
+            UIColor(red: 0.2, green: 0.7, blue: 0.85, alpha: 1).setFill()
+            context.cgContext.fill(CGRect(x: 260, y: 780, width: 460, height: 120))
+        }
+        return image.jpegData(compressionQuality: 0.82) ?? Data()
     }
 
     private func currentVideoRotationAngle() -> CGFloat {

--- a/AllHandsOnDeck/Core/Services/Session/SupabaseSessionTransport.swift
+++ b/AllHandsOnDeck/Core/Services/Session/SupabaseSessionTransport.swift
@@ -17,7 +17,27 @@ final class SupabaseSessionTransport: SessionTransport {
     }
 
     static var isConfigured: Bool {
-        !supabaseURLString.isEmpty && !anonKey.isEmpty
+        hasUsableConfig(url: supabaseURLString, anonKey: anonKey)
+    }
+
+    nonisolated static func hasUsableConfig(url: String, anonKey: String) -> Bool {
+        let trimmedURL = url.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedKey = anonKey.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !trimmedURL.isEmpty,
+              !trimmedKey.isEmpty,
+              !trimmedURL.contains("YOUR-PROJECT-REF"),
+              trimmedKey != "TODO",
+              let parsedURL = URL(string: trimmedURL),
+              let scheme = parsedURL.scheme?.lowercased(),
+              ["http", "https"].contains(scheme),
+              let host = parsedURL.host?.lowercased(),
+              host.hasSuffix(".supabase.co")
+        else {
+            return false
+        }
+
+        return trimmedKey.split(separator: ".").count == 3
     }
 
     // MARK: - SessionTransport

--- a/AllHandsOnDeck/Features/Host/HostSessionView.swift
+++ b/AllHandsOnDeck/Features/Host/HostSessionView.swift
@@ -124,12 +124,14 @@ struct HostSessionView: View {
                     .transition(.opacity)
             }
 
-            if showDebugOverlays {
+            if showDebugOverlays && !isPhotoReviewActive {
                 DebugOverlayView()
             }
 
-            GeometryReader { proxy in
-                hostChrome(in: proxy)
+            if !isPhotoReviewActive {
+                GeometryReader { proxy in
+                    hostChrome(in: proxy)
+                }
             }
 
         }
@@ -225,7 +227,7 @@ struct HostSessionView: View {
         VStack(spacing: 0) {
             topBar
                 .padding(.horizontal, Spacing.lg)
-                .padding(.top, max(proxy.safeAreaInsets.top, Spacing.xl) + Spacing.sm)
+                .padding(.top, Spacing.lg)
                 .padding(.bottom, Spacing.sm)
 
             Spacer(minLength: 0)
@@ -236,6 +238,10 @@ struct HostSessionView: View {
         }
         .frame(width: proxy.size.width, height: proxy.size.height, alignment: .top)
         .clipped(antialiased: false)
+    }
+
+    private var isPhotoReviewActive: Bool {
+        vm.capturedPhoto != nil || !vm.burstCandidates.isEmpty
     }
 
     private func flashZoomLabel() {
@@ -546,12 +552,14 @@ struct HostSessionView: View {
                         .padding(.horizontal, 16)
                 }
                 HStack(spacing: 10) {
-                    PrimaryButton(title: "Noch einmal", systemImage: "arrow.counterclockwise", style: .secondary) {
+                    PrimaryButton(title: DesignLabels.retake, systemImage: "arrow.counterclockwise", style: .secondary) {
                         vm.discardCapture()
                     }
-                    PrimaryButton(title: "Speichern", systemImage: "square.and.arrow.down", style: .primary) {
+                    .accessibilityIdentifier("host_retake_photo")
+                    PrimaryButton(title: DesignLabels.save, systemImage: "square.and.arrow.down", style: .primary) {
                         savePhoto(photo)
                     }
+                    .accessibilityIdentifier("host_save_photo")
                 }
                 .padding(.horizontal, 16)
                 .padding(.bottom, 24)

--- a/AllHandsOnDeckTests/PhotoSessionTests.swift
+++ b/AllHandsOnDeckTests/PhotoSessionTests.swift
@@ -47,6 +47,39 @@ final class PhotoSessionTests: XCTestCase {
         XCTAssertEqual(s.joinURL.absoluteString, "http://10.0.0.5:5173/join/ABCDEF1234")
     }
 
+    func test_joinURL_trimsTrailingSlashAndIncludesShortLivedToken() throws {
+        let key = "joinBaseURL"
+        let original = UserDefaults.standard.string(forKey: key)
+        defer {
+            if let original {
+                UserDefaults.standard.set(original, forKey: key)
+            } else {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+
+        UserDefaults.standard.set("https://allhandsondeck.app/", forKey: key)
+        let issuedAt = Date(timeIntervalSince1970: 1_778_017_608)
+        let s = PhotoSession(
+            id: "7NMDA6TAE9",
+            hostName: "Captain",
+            joinToken: JoinToken(
+                sessionID: "7NMDA6TAE9",
+                value: "token-123",
+                issuedAt: issuedAt,
+                ttlMinutes: 10
+            )
+        )
+
+        let url = try XCTUnwrap(URLComponents(url: s.joinURL, resolvingAgainstBaseURL: false))
+        XCTAssertEqual(url.scheme, "https")
+        XCTAssertEqual(url.host, "allhandsondeck.app")
+        XCTAssertEqual(url.path, "/join/7NMDA6TAE9")
+        XCTAssertEqual(url.queryItems?.first(where: { $0.name == "session_id" })?.value, "7NMDA6TAE9")
+        XCTAssertEqual(url.queryItems?.first(where: { $0.name == "token" })?.value, "token-123")
+        XCTAssertNotNil(url.queryItems?.first(where: { $0.name == "expires_at" })?.value)
+    }
+
     func test_joinURL_fallsBackToCustomSchemeWhenNoWebBaseConfigured() {
         let key = "joinBaseURL"
         let original = UserDefaults.standard.string(forKey: key)

--- a/AllHandsOnDeckTests/SupabaseConfigurationTests.swift
+++ b/AllHandsOnDeckTests/SupabaseConfigurationTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import AllHandsOnDeck
+
+final class SupabaseConfigurationTests: XCTestCase {
+    func test_supabaseConfigRejectsEmptyAndTemplateValues() {
+        XCTAssertFalse(SupabaseSessionTransport.hasUsableConfig(url: "", anonKey: ""))
+        XCTAssertFalse(SupabaseSessionTransport.hasUsableConfig(url: "https://YOUR-PROJECT-REF.supabase.co", anonKey: "TODO"))
+        XCTAssertFalse(SupabaseSessionTransport.hasUsableConfig(url: "https://edylzgxrknbqjdgtrgic.supabase.co", anonKey: "TODO"))
+    }
+
+    func test_supabaseConfigAcceptsProjectURLAndAnonJWT() {
+        let anon = [
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+            "eyJyb2xlIjoiYW5vbiJ9",
+            "signature"
+        ].joined(separator: ".")
+
+        XCTAssertTrue(SupabaseSessionTransport.hasUsableConfig(
+            url: "https://edylzgxrknbqjdgtrgic.supabase.co",
+            anonKey: anon
+        ))
+    }
+}

--- a/AllHandsOnDeckUITests/HappyPathUITests.swift
+++ b/AllHandsOnDeckUITests/HappyPathUITests.swift
@@ -98,7 +98,7 @@ final class HappyPathUITests: XCTestCase {
         }
 
         let screen = app.frame
-        let topBand = screen.minY + 24...screen.minY + 180
+        let topBand = screen.minY + 24...screen.minY + 132
         let bottomBand = screen.maxY - 150...screen.maxY - 20
 
         let topButtons = [
@@ -120,6 +120,21 @@ final class HappyPathUITests: XCTestCase {
             XCTAssertTrue(button.waitForExistence(timeout: 5), "Missing bottom chrome button: \(button)")
             assertButton(button, staysInside: bottomBand, axis: .vertical)
         }
+    }
+
+    func test_photoReview_hidesLiveCaptureControlsAndKeepsReviewActionsVisible() throws {
+        tapStartCrewPhoto()
+        guard anyHostSessionElementExists() else {
+            XCTFail("Host session not reached"); return
+        }
+
+        app.buttons["host_capture_now"].tap()
+
+        XCTAssertTrue(app.buttons["host_retake_photo"].waitForExistence(timeout: 8), "Retake action missing after capture")
+        XCTAssertTrue(app.buttons["host_save_photo"].waitForExistence(timeout: 2), "Save action missing after capture")
+        XCTAssertFalse(app.buttons["host_start_timer"].exists, "Start timer should be hidden while reviewing a captured photo")
+        XCTAssertFalse(app.buttons["host_capture_now"].exists, "Capture-now should be hidden while reviewing a captured photo")
+        XCTAssertFalse(app.staticTexts["Nobody in frame"].exists, "In-frame warning should be hidden while reviewing a captured photo")
     }
 
     // MARK: - Viewer: Crew Interaction ──────────────────────────────────────────

--- a/webapp/e2e/happy-path.spec.ts
+++ b/webapp/e2e/happy-path.spec.ts
@@ -60,6 +60,15 @@ test.describe("Happy Path — Join Page (no backend)", () => {
     await expect(page.locator("body")).toBeVisible();
   });
 
+  test("opens iOS QR join URL with short-lived token query", async ({ page }) => {
+    await page.goto("/join/7NMDA6TAE9?session_id=7NMDA6TAE9&token=test-token&expires_at=2026-05-06T18%3A00%3A00Z");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page).toHaveURL(/\/join\/7NMDA6TAE9\?/);
+    await expect(page.getByText("7NMDA6TAE9")).toBeVisible();
+    await expect(page.locator("body")).toBeVisible();
+  });
+
   test("shows content without crashing", async ({ page }) => {
     await page.goto("/join/HAPPYTEST");
     await page.waitForLoadState("networkidle");


### PR DESCRIPTION
Linear: https://linear.app/captain-leopard-ai-engineering/issue/APP-86/fix-web-viewer-beta-qr-join-and-host-photo-review-ui
GitHub Issue: https://github.com/alexanderbrunker-star/AllHandsOnDeck/issues/44

## Summary
- Normalize iOS QR join URLs so a trailing web base slash cannot produce `//join/...`.
- Harden Supabase beta config validation so placeholders/TODO values are not treated as usable config.
- Move host top chrome into the tested upper layout band.
- Hide live host chrome, debug overlay, and in-frame warnings while reviewing a captured photo.
- Add deterministic UI-test photo capture for the camera bypass path.

## Test Plan
- `xcodebuild -project AllHandsOnDeck.xcodeproj -scheme AllHandsOnDeck -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' -only-testing:AllHandsOnDeckTests/PhotoSessionTests/test_joinURL_trimsTrailingSlashAndIncludesShortLivedToken test`
- `xcodebuild -project AllHandsOnDeck.xcodeproj -scheme AllHandsOnDeck -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' -only-testing:AllHandsOnDeckTests/SupabaseConfigurationTests test`
- `xcodebuild -project AllHandsOnDeck.xcodeproj -scheme AllHandsOnDeck -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' -only-testing:AllHandsOnDeckUITests/HappyPathUITests/test_hostChromeButtonsStayWithinSafeLayoutBands -only-testing:AllHandsOnDeckUITests/HappyPathUITests/test_photoReview_hidesLiveCaptureControlsAndKeepsReviewActionsVisible test`
- `cd webapp && npm test`
- `cd webapp && npm run build`
- `cd webapp && npx playwright test e2e/happy-path.spec.ts`
- `swiftlint --strict --config .swiftlint.yml`
- Browser automation: opened `http://127.0.0.1:5173/join/7NMDA6TAE9?session_id=7NMDA6TAE9&token=test-token&expires_at=2026-05-06T18%3A00%3A00Z` and verified the join page rendered the session id.

## Checklist
- [x] DesignLabels used for host review buttons.
- [x] Accessibility identifiers added for review actions.
- [x] Regression tests added for QR, Supabase config, host chrome bounds, photo review state, and web QR join URL.
- [x] No service-role secret in client code.