### PR TITLE
[APP-92] Fix host crew and settings overlay spacing

### DIFF
--- a/AllHandsOnDeck/Features/Host/HostSessionView.swift
+++ b/AllHandsOnDeck/Features/Host/HostSessionView.swift
@@ -59,25 +59,28 @@ struct HostSessionView: View {
             .allowsHitTesting(false)
 
             // Backdrop behind popups — tap empty space to dismiss both
-            if crewOpen || showQR {
+            if !showSettings && (crewOpen || showQR) {
                 Color.black.opacity(0.25)
                     .ignoresSafeArea(edges: .all)
                     .onTapGesture { withAnimation { crewOpen = false; showQR = false } }
                     .transition(.opacity)
             }
 
-            // Crew popup in UPPER area — liquid glass, camera visible through blur
-            if crewOpen {
-                VStack(spacing: 0) {
-                    Spacer().frame(height: 60)
-                    crewPopup
-                    Spacer()
+            if crewOpen && !showSettings {
+                GeometryReader { proxy in
+                    VStack(spacing: 0) {
+                        Spacer().frame(height: crewPopupTopOffset(in: proxy))
+                        crewPopup
+                            .frame(maxHeight: crewPopupMaxHeight(in: proxy))
+                        Spacer(minLength: 0)
+                    }
+                    .frame(width: proxy.size.width, height: proxy.size.height, alignment: .top)
+                    .allowsHitTesting(true)
                 }
                 .transition(.opacity)
             }
 
-            // QR popup in LOWER area — liquid glass, camera visible through blur
-            if showQR {
+            if showQR && !showSettings {
                 VStack(spacing: 0) {
                     Spacer()
                     QRCodePanelView(payload: vm.qrPayload, sessionID: vm.session.id)
@@ -124,11 +127,11 @@ struct HostSessionView: View {
                     .transition(.opacity)
             }
 
-            if showDebugOverlays && !isPhotoReviewActive {
+            if showDebugOverlays && !isPhotoReviewActive && !showSettings {
                 DebugOverlayView()
             }
 
-            if !isPhotoReviewActive {
+            if !isPhotoReviewActive && !showSettings {
                 GeometryReader { proxy in
                     hostChrome(in: proxy)
                 }
@@ -221,6 +224,16 @@ struct HostSessionView: View {
         .padding(14)
         .frame(width: 260)
         .liquidGlass()
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("host_crew_popup")
+    }
+
+    private func crewPopupTopOffset(in proxy: GeometryProxy) -> CGFloat {
+        max(proxy.safeAreaInsets.top + 76, 116)
+    }
+
+    private func crewPopupMaxHeight(in proxy: GeometryProxy) -> CGFloat {
+        max(150, proxy.size.height * 0.26)
     }
 
     private func hostChrome(in proxy: GeometryProxy) -> some View {
@@ -275,7 +288,10 @@ struct HostSessionView: View {
                 qrToggleButton
 
                 Button {
-                    withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) { crewOpen.toggle() }
+                    withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+                        showSettings = false
+                        crewOpen.toggle()
+                    }
                 } label: {
                     ZStack {
                         Image(systemName: DesignLabels.iconCrew)
@@ -296,10 +312,19 @@ struct HostSessionView: View {
                     }
                 }
                 .buttonStyle(.plain)
-                .accessibilityIdentifier("host_crew_count_\(vm.participants.count)")
+                .accessibilityLabel(DesignLabels.crew)
+                .accessibilityValue("\(vm.participants.count)")
+                .accessibilityIdentifier("host_crew")
 
                 Button {
-                    withAnimation { showSettings.toggle() }
+                    withAnimation {
+                        let opens = !showSettings
+                        showSettings = opens
+                        if opens {
+                            crewOpen = false
+                            showQR = false
+                        }
+                    }
                 } label: {
                     Image(systemName: "slider.horizontal.3")
                         .font(.system(size: 16, weight: .heavy))
@@ -313,26 +338,28 @@ struct HostSessionView: View {
                 .accessibilityIdentifier("host_settings")
             }
 
-            HStack(spacing: 10) {
-                LensSelectorView(camera: vm.camera, onSelect: { lens in
-                    vm.camera.switchLens(lens)
-                    switch lens {
-                    case .ultraWide: baseZoom = vm.camera.minVirtualZoom
-                    case .wide:      baseZoom = 1.0
-                    case .tele:      baseZoom = vm.camera.teleEquivalentZoom
-                    }
-                    flashZoomLabel()
-                })
+            if !crewOpen {
+                HStack(spacing: 10) {
+                    LensSelectorView(camera: vm.camera, onSelect: { lens in
+                        vm.camera.switchLens(lens)
+                        switch lens {
+                        case .ultraWide: baseZoom = vm.camera.minVirtualZoom
+                        case .wide:      baseZoom = 1.0
+                        case .tele:      baseZoom = vm.camera.teleEquivalentZoom
+                        }
+                        flashZoomLabel()
+                    })
 
-                Spacer()
+                    Spacer()
 
-                HighResButton(camera: vm.camera)
+                    HighResButton(camera: vm.camera)
 
-                // Torch + flip — observes camera directly so only these buttons re-render.
-                CameraButtons(camera: vm.camera, onFlip: {
-                    withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) { baseZoom = 1.0 }
-                    vm.camera.flipCamera()
-                })
+                    CameraButtons(camera: vm.camera, onFlip: {
+                        withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) { baseZoom = 1.0 }
+                        vm.camera.flipCamera()
+                    })
+                }
+                .accessibilityIdentifier("host_camera_controls")
             }
         }
     }
@@ -512,13 +539,6 @@ struct HostSessionView: View {
                 isOn: $showLevel
             )
 
-            ParticipantListView(
-                participants: vm.participants,
-                pendingRequestIDs: vm.pendingCaptureRequests,
-                onApprove: { id in Task { await vm.approve(participantID: id) } },
-                onDeny: { id in Task { await vm.deny(participantID: id) } }
-            )
-
             PrimaryButton(title: DesignLabels.close, style: .ghost) {
                 withAnimation { showSettings = false }
             }
@@ -537,6 +557,8 @@ struct HostSessionView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
         .padding(.horizontal, 8)
         .ignoresSafeArea(edges: .bottom)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("host_settings_sheet")
     }
 
     @ViewBuilder

--- a/AllHandsOnDeck/Features/Host/QRCodePanelView.swift
+++ b/AllHandsOnDeck/Features/Host/QRCodePanelView.swift
@@ -68,6 +68,8 @@ struct QRCodePanelView: View {
         }
         .padding(12)
         .liquidGlass()
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("host_qr_panel")
     }
 }
 

--- a/AllHandsOnDeck/Shared/Components/DebugOverlayView.swift
+++ b/AllHandsOnDeck/Shared/Components/DebugOverlayView.swift
@@ -5,7 +5,7 @@ struct DebugOverlayView: View {
     @State private var expanded = false
     let version: String
 
-    init(version: String = "2.4.0") {
+    init(version: String = "2.4.1") {
         self.version = version
     }
 

--- a/AllHandsOnDeckUITests/HappyPathUITests.swift
+++ b/AllHandsOnDeckUITests/HappyPathUITests.swift
@@ -137,6 +137,52 @@ final class HappyPathUITests: XCTestCase {
         XCTAssertFalse(app.staticTexts["Nobody in frame"].exists, "In-frame warning should be hidden while reviewing a captured photo")
     }
 
+    func test_crewPopupFitsBetweenTopChromeAndQRCode() throws {
+        tapStartCrewPhoto()
+        guard anyHostSessionElementExists() else {
+            XCTFail("Host session not reached"); return
+        }
+
+        app.buttons["host_crew"].tap()
+
+        let crewPopup = app.otherElements["host_crew_popup"]
+        let qrPanel = app.otherElements["host_qr_panel"]
+        XCTAssertTrue(crewPopup.waitForExistence(timeout: 5), "Crew popup missing")
+        XCTAssertTrue(qrPanel.waitForExistence(timeout: 5), "QR panel missing")
+        XCTAssertTrue(app.buttons["host_qr_toggle"].exists, "Top QR button should remain available")
+        XCTAssertTrue(app.buttons["host_settings"].exists, "Top settings button should remain available")
+
+        XCTAssertFalse(app.otherElements["host_camera_controls"].exists, "Camera controls should not overlap the crew popup")
+        XCTAssertLessThanOrEqual(
+            app.buttons["host_crew"].frame.maxY + 24,
+            crewPopup.frame.minY,
+            "Crew popup overlaps top action icons"
+        )
+        XCTAssertLessThanOrEqual(
+            crewPopup.frame.maxY + 24,
+            qrPanel.frame.minY,
+            "Crew popup overlaps QR panel"
+        )
+    }
+
+    func test_settingsSheetHidesCameraChromeAndCrewList() throws {
+        tapStartCrewPhoto()
+        guard anyHostSessionElementExists() else {
+            XCTFail("Host session not reached"); return
+        }
+
+        app.buttons["host_settings"].tap()
+
+        let sheet = app.otherElements["host_settings_sheet"]
+        XCTAssertTrue(sheet.waitForExistence(timeout: 5), "Settings sheet missing")
+        XCTAssertFalse(app.buttons["host_qr_toggle"].exists, "QR top button should be hidden while settings is open")
+        XCTAssertFalse(app.buttons["host_crew"].exists, "Crew top button should be hidden while settings is open")
+        XCTAssertFalse(app.otherElements["host_camera_controls"].exists, "Camera controls should be hidden while settings is open")
+        XCTAssertFalse(app.buttons["host_start_timer"].exists, "Bottom timer should be hidden while settings is open")
+        XCTAssertFalse(app.buttons["host_capture_now"].exists, "Capture-now should be hidden while settings is open")
+        XCTAssertFalse(app.otherElements["host_settings_crew_section"].exists, "Crew section should be removed from settings")
+    }
+
     // MARK: - Viewer: Crew Interaction ──────────────────────────────────────────
 
     func test_joinSession_reachesViewerSessionView() throws {

--- a/webapp/src/JoinPage.tsx
+++ b/webapp/src/JoinPage.tsx
@@ -307,7 +307,7 @@ function DebugPanel({ open, onToggle }: { open: boolean; onToggle: () => void })
       <button onClick={onToggle} className="debug-bar">
         <span className="debug-dot" />
         <span>{ds.framesPerSecond}fps SB:{ds.framesReceived}/{ds.supabaseEvents} {ds.lastEvent}</span>
-        <span className="debug-version">v2.4.0</span>
+        <span className="debug-version">v2.4.1</span>
         <span style={{ marginLeft: 'auto' }}>{open ? '▼' : '▲'}</span>
       </button>
       {open && (


### PR DESCRIPTION
Linear: https://linear.app/captain-leopard-ai-engineering/issue/APP-92/fix-host-crew-and-settings-overlay-spacing
GitHub Issue: https://github.com/alexanderbrunker-star/AllHandsOnDeck/issues/46

## Summary
- Repositions Crew popup into the safe space above the QR panel and below top action icons.
- Hides second-row camera controls while Crew popup is open.
- Makes Settings modal-exclusive by hiding host chrome, QR/Crew overlays, bottom capture controls, and debug overlay.
- Removes the Crew list from Settings.
- Bumps visible debug version to 2.4.1.

## Test Plan
- [x] xcodebuild -project AllHandsOnDeck.xcodeproj -scheme AllHandsOnDeck -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' -only-testing:AllHandsOnDeckUITests/HappyPathUITests/test_crewPopupFitsBetweenTopChromeAndQRCode -only-testing:AllHandsOnDeckUITests/HappyPathUITests/test_settingsSheetHidesCameraChromeAndCrewList test
- [x] xcodebuild -project AllHandsOnDeck.xcodeproj -scheme AllHandsOnDeck -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' -only-testing:AllHandsOnDeckUITests/HappyPathUITests/test_hostChromeButtonsStayWithinSafeLayoutBands test
- [x] swiftlint --strict --config .swiftlint.yml
- [x] cd webapp && npm run build && npm test

## Screenshot Evidence
- Regression covered by UI tests measuring popup frames and hidden chrome states on iPhone 17 Pro Max simulator.

## Checklist
- [x] Linear issue linked
- [x] GitHub issue linked
- [x] Tests green locally
- [x] No user-facing strings added outside existing labels

Closes #46